### PR TITLE
Make abbreviations in cron expressions case insensitive

### DIFF
--- a/quartz/cron.go
+++ b/quartz/cron.go
@@ -112,8 +112,8 @@ func (cf *CronField) String() string {
 }
 
 var (
-	months      = []string{"0", "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"}
-	days        = []string{"0", "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"}
+	months      = []string{"0", "JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"}
+	days        = []string{"0", "SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"}
 	daysInMonth = []int{0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31}
 
 	// the pre-defined cron expressions

--- a/quartz/cron_test.go
+++ b/quartz/cron_test.go
@@ -37,7 +37,7 @@ func TestCronExpression2(t *testing.T) {
 func TestCronExpression3(t *testing.T) {
 	prev := int64(1555351200000000000)
 	result := ""
-	cronTrigger, err := quartz.NewCronTrigger("* 5,7,9 14/2 * * Wed,Sat *")
+	cronTrigger, err := quartz.NewCronTrigger("* 5,7,9 14/2 * * WED,Sat *")
 	if err != nil {
 		t.Fatal(err)
 	} else {
@@ -69,7 +69,7 @@ func TestCronExpression5(t *testing.T) {
 func TestCronExpression6(t *testing.T) {
 	prev := int64(1555351200000000000)
 	result := ""
-	cronTrigger, err := quartz.NewCronTrigger("* * 14/2 * * Mon/3 *")
+	cronTrigger, err := quartz.NewCronTrigger("* * 14/2 * * mon/3 *")
 	if err != nil {
 		t.Fatal(err)
 	} else {

--- a/quartz/util.go
+++ b/quartz/util.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -64,13 +65,13 @@ func fillStep(from, step, max int) ([]int, error) {
 	return arr, nil
 }
 
-func normalize(field string, tr []string) int {
+func normalize(field string, dict []string) int {
 	i, err := strconv.Atoi(field)
 	if err == nil {
 		return i
 	}
 
-	return intVal(tr, field)
+	return intVal(dict, field)
 }
 
 func inScope(i, min, max int) bool {
@@ -104,8 +105,9 @@ func step(prev, next, max int) int {
 }
 
 func intVal(target []string, search string) int {
+	uSearch := strings.ToUpper(search)
 	for i, v := range target {
-		if v == search {
+		if v == uSearch {
 			return i
 		}
 	}


### PR DESCRIPTION
Resolves #25.