### PR TITLE
fix division by zero when parsing step field

### DIFF
--- a/quartz/cron.go
+++ b/quartz/cron.go
@@ -354,7 +354,7 @@ func parseStepField(field string, min int, max int, translate []string) (*cronFi
 
 	from := normalize(t[0], translate)
 	step := atoi(t[1])
-	if !inScope(from, min, max) {
+	if !inScope(from, min, max) || step == 0 {
 		return nil, cronError("Cron step min/max validation error")
 	}
 

--- a/quartz/cron_test.go
+++ b/quartz/cron_test.go
@@ -227,3 +227,17 @@ func iterate(prev int64, cronTrigger *quartz.CronTrigger, iterations int) (strin
 	}
 	return time.Unix(prev/int64(time.Second), 0).UTC().Format(readDateLayout), nil
 }
+
+func TestCronExpressionError(t *testing.T) {
+	tests := []string{
+		"*/X * * * * *",
+	}
+	for _, test := range tests {
+		t.Run(test, func(t *testing.T) {
+			_, err := quartz.NewCronTrigger(test)
+			if err == nil {
+				t.Error("expected error")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Zero or non-integer step field causes panic instead of parsing error.