### PR TITLE
scheduler: avoid dispatching jobs too early

### DIFF
--- a/quartz/function_job_test.go
+++ b/quartz/function_job_test.go
@@ -26,9 +26,10 @@ func TestFunctionJob(t *testing.T) {
 
 	sched := quartz.NewStdScheduler()
 	sched.Start(ctx)
-	sched.ScheduleJob(ctx, funcJob1, quartz.NewRunOnceTrigger(time.Millisecond*300))
-	sched.ScheduleJob(ctx, funcJob2, quartz.NewRunOnceTrigger(time.Millisecond*800))
+	sched.ScheduleJob(ctx, funcJob1, quartz.NewRunOnceTrigger(100*time.Millisecond))
+	sched.ScheduleJob(ctx, funcJob2, quartz.NewRunOnceTrigger(200*time.Millisecond))
 	time.Sleep(time.Second)
+
 	sched.Clear()
 	sched.Stop()
 

--- a/quartz/scheduler.go
+++ b/quartz/scheduler.go
@@ -333,7 +333,8 @@ func (sched *StdScheduler) executeAndReschedule(ctx context.Context) {
 		it = heap.Pop(sched.queue).(*item)
 	}()
 
-	// if there isn't actually a job ready to run now, we'll sleep again
+	// if there isn't actually a job ready to run now, we'll
+	// return early and try again.
 	if it == nil {
 		return
 	}
@@ -396,12 +397,4 @@ func (sched *StdScheduler) reset(ctx context.Context, next time.Time) {
 	case <-ctx.Done():
 	default:
 	}
-}
-
-func parkTime(ts int64) int64 {
-	now := NowNano()
-	if ts > now {
-		return ts - now
-	}
-	return 0
 }

--- a/quartz/util_test.go
+++ b/quartz/util_test.go
@@ -8,12 +8,14 @@ import (
 )
 
 func assertEqual[T any](t *testing.T, a T, b T) {
+	t.Helper()
 	if !reflect.DeepEqual(a, b) {
 		t.Fatalf("%v != %v", a, b)
 	}
 }
 
 func assertNotEqual[T any](t *testing.T, a T, b T) {
+	t.Helper()
 	if reflect.DeepEqual(a, b) {
 		t.Fatalf("%v == %v", a, b)
 	}


### PR DESCRIPTION
I don't believe that this is final (and many of the tests don't work, yet with this configuration which I expect a bit.) However, I wanted to submit it here as a conversation starter: 

- Even with the isolated job stuff that I added a few months ago, it seems that we're still trying to dispatch a single job in a scheduler more than once. My current (albeit very much working) theory, is that because the priority queue is maintained asynchronously with regards to the waiting/dispatching, we could begin sleeping and waiting for the "next" job in the queue, and by the time we wakeup from sleeping another job could be ready? It seems a bit far fetched, however... 
- As a, perhaps more plausible theory (or contributing factor), the [`isOutdated`](https://github.com/reugn/go-quartz/blob/more-adpative-waiting/quartz/util.go#L111-L113) function will run a job if it's going to be "due" for the next 30 seconds. We regularly run jobs with very short intervals (the one that's experiencing the most "collisions" runs every 5 seconds, so maybe a better fix is to just remove this 30 second buffer entirely.

Anyway, please let me know what you think, and I'm not committed to this particular patch at all. 