### PR TITLE
Adds SetHttpClient and unit tests for mocking curl job executes

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,5 +99,14 @@ sched.Wait(ctx)
 ```
 More code samples can be found in the examples directory.
 
+## Setting Custom Http Client
+
+```go
+client := &http.Client{Timeout: 5 * time.Second}
+
+// All CurlJob requests will now use this client
+quartz.SetHttpClient(client)
+```
+
 ## License
 Licensed under the MIT License.

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ More code samples can be found in the examples directory.
 client := &http.Client{Timeout: 5 * time.Second}
 
 // All CurlJob requests will now use this client
-quartz.SetHttpClient(client)
+quartz.SetHTTPClient(client)
 ```
 
 ## License

--- a/quartz/job.go
+++ b/quartz/job.go
@@ -26,6 +26,9 @@ type Job interface {
 // JobStatus represents a Job status.
 type JobStatus int8
 
+// httpClient is the internal http.Client used by CurlJob to execute http requests
+var httpClient http.Client
+
 const (
 	// NA is the initial Job status.
 	NA JobStatus = iota
@@ -129,9 +132,14 @@ func (cu *CurlJob) Key() int {
 	return HashCode(cu.Description())
 }
 
+// SetHttpClient allows the http client to be set for all CurlJob requests
+func SetHttpClient(c *http.Client) {
+	httpClient = *c
+}
+
 // Execute is called by a Scheduler when the Trigger associated with this job fires.
 func (cu *CurlJob) Execute(ctx context.Context) {
-	client := &http.Client{}
+	client := httpClient
 	cu.request = cu.request.WithContext(ctx)
 	resp, err := client.Do(cu.request)
 	if err != nil {

--- a/quartz/job.go
+++ b/quartz/job.go
@@ -132,8 +132,8 @@ func (cu *CurlJob) Key() int {
 	return HashCode(cu.Description())
 }
 
-// SetHttpClient allows the http client to be set for all CurlJob requests
-func SetHttpClient(c *http.Client) {
+// SetHTTPClient allows the http client to be set for all CurlJob requests
+func SetHTTPClient(c *http.Client) {
 	httpClient = *c
 }
 

--- a/quartz/job_test.go
+++ b/quartz/job_test.go
@@ -139,7 +139,7 @@ func TestCurlJobExecute(t *testing.T) {
 
 	// set mock client to http client
 	mockClient := &http.Client{}
-	quartz.SetHttpClient(mockClient)
+	quartz.SetHTTPClient(mockClient)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/quartz/job_test.go
+++ b/quartz/job_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"math/rand"
+	"net/http"
+	"net/http/httptest"
 	"runtime"
 	"sync/atomic"
 	"testing"
@@ -81,4 +83,95 @@ func TestMultipleExecution(t *testing.T) {
 	if atomic.LoadInt64(&n) != 1 {
 		t.Error("only one job should run")
 	}
+}
+
+func TestCurlJobExecute(t *testing.T) {
+	tests := []struct {
+		name       string
+		handler    http.Handler
+		jobStatus  quartz.JobStatus
+		statusCode int
+		respBody   string
+	}{
+		{
+			name: "Http 200 Success",
+			handler: http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				rw.WriteHeader(http.StatusOK)
+				_, err := rw.Write([]byte(`Http 200 Response`))
+				if err != nil {
+					return
+				}
+			}),
+			jobStatus:  quartz.OK,
+			statusCode: http.StatusOK,
+			respBody:   "Http 200 Response",
+		},
+		{
+			name: "Http 302 Success",
+			handler: http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				rw.WriteHeader(http.StatusFound)
+				_, err := rw.Write([]byte(`Http 302 Response`))
+				if err != nil {
+					return
+				}
+			}),
+			jobStatus:  quartz.OK,
+			statusCode: http.StatusFound,
+			respBody:   "Http 302 Response",
+		},
+		{
+			name: "Http 500 Failure",
+			handler: http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				rw.WriteHeader(http.StatusInternalServerError)
+				_, err := rw.Write([]byte(`Http 500 Response`))
+				if err != nil {
+					return
+				}
+			}),
+			jobStatus:  quartz.FAILURE,
+			statusCode: http.StatusInternalServerError,
+			respBody:   "Http 500 Response",
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// set mock client to http client
+	mockClient := &http.Client{}
+	quartz.SetHttpClient(mockClient)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(tt.handler)
+			defer server.Close()
+
+			// create a new CurlJob
+			job, err := quartz.NewCurlJob(http.MethodGet, server.URL, "", nil)
+			assertEqual(t, err, nil)
+
+			job.Execute(ctx)
+
+			assertEqual(t, job.JobStatus, tt.jobStatus)
+			assertEqual(t, job.StatusCode, tt.statusCode)
+			assertEqual(t, job.Response, tt.respBody)
+		})
+	}
+}
+
+func TestCurlJobExecuteWithCancelledContext(t *testing.T) {
+	// create a new CurlJob
+	job, err := quartz.NewCurlJob(http.MethodGet, "https://example.com", "", nil)
+	assertEqual(t, err, nil)
+
+	// The context is canceled to test the job execute going down the unhappy path of
+	// the http.Client returning an error
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	job.Execute(ctx)
+
+	assertEqual(t, job.JobStatus, quartz.FAILURE)
+	assertEqual(t, job.StatusCode, -1)
+	assertEqual(t, job.Response, "Get \"https://example.com\": context canceled")
 }


### PR DESCRIPTION
Hi

This adds a new feature by adding in a SetHttpClient function.

On the execute of CurlJob the http.Client is hard coded in

```golang
// Execute is called by a Scheduler when the Trigger associated with this job fires.
func (cu *CurlJob) Execute(ctx context.Context) {
	client := &http.Client{}
	cu.request = cu.request.WithContext(ctx)
	resp, err := client.Do(cu.request)
```

This makes setting any custom http.Client impossible. This ticket adds in that functionality and also mocks all CurlJob Executes with unit tests using httptest.NewServer

Docs are also updated.

Happy to refactor out SetHttpClient if requested but I would think it is best to keep the unit tests.