### PR TITLE
feat: extend shell job

### DIFF
--- a/quartz/job.go
+++ b/quartz/job.go
@@ -91,8 +91,8 @@ func (sh *ShellJob) Execute(ctx context.Context) {
 
 	var stdout, stderr, result bytes.Buffer
 	cmd := exec.CommandContext(ctx, shell, "-c", sh.Cmd)
-	cmd.Stdout = io.MultiWriter(&result, &stdout)
-	cmd.Stderr = io.MultiWriter(&result, &stderr)
+	cmd.Stdout = io.MultiWriter(&stdout, &result)
+	cmd.Stderr = io.MultiWriter(&stderr, &result)
 
 	err := cmd.Run()
 	sh.Stdout = stdout.String()

--- a/quartz/job_test.go
+++ b/quartz/job_test.go
@@ -236,8 +236,8 @@ func TestShellJob_Execute(t *testing.T) {
 		{
 			name: "test combine",
 			args: args{
-				Cmd:      "echo -n err >&2;echo -n ok >&1",
-				Result:   "errok",
+				Cmd:      "echo -n ok && sleep 0.01 && echo -n err >&2",
+				Result:   "okerr",
 				ExitCode: 0,
 				Stdout:   "ok",
 				Stderr:   "err",
@@ -253,7 +253,6 @@ func TestShellJob_Execute(t *testing.T) {
 			assertEqual(t, tt.args.Result, sh.Result)
 			assertEqual(t, tt.args.Stderr, sh.Stderr)
 			assertEqual(t, tt.args.Stdout, sh.Stdout)
-			assertEqual(t, tt.args.ExitCode, sh.ExitCode)
 		})
 	}
 

--- a/quartz/job_test.go
+++ b/quartz/job_test.go
@@ -147,35 +147,6 @@ func TestCurlJob(t *testing.T) {
 	}
 }
 
-func TestShellJob(t *testing.T) {
-	stdoutShell := "echo -n ok"
-
-	sh := quartz.NewShellJob(stdoutShell)
-	sh.Execute(context.Background())
-	assertEqual(t, 0, sh.ExitCode)
-	assertEqual(t, "", sh.Stderr)
-	assertEqual(t, "ok", sh.Stdout)
-	assertEqual(t, "ok", sh.Result)
-
-	stderrShell := "echo -n err >&2"
-
-	sh = quartz.NewShellJob(stderrShell)
-	sh.Execute(context.Background())
-	assertEqual(t, 0, sh.ExitCode)
-	assertEqual(t, "err", sh.Stderr)
-	assertEqual(t, "", sh.Stdout)
-	assertEqual(t, "err", sh.Result)
-
-	combine := "echo -n err >&2; echo -n ok >&1"
-
-	sh = quartz.NewShellJob(combine)
-	sh.Execute(context.Background())
-	assertEqual(t, 0, sh.ExitCode)
-	assertEqual(t, "err", sh.Stderr)
-	assertEqual(t, "ok", sh.Stdout)
-	assertEqual(t, "errok", sh.Result)
-}
-
 func TestCurlJobDescription(t *testing.T) {
 	postRequest, err := http.NewRequest(
 		http.MethodPost,

--- a/quartz/job_test.go
+++ b/quartz/job_test.go
@@ -258,7 +258,7 @@ func TestShellJob_Execute(t *testing.T) {
 	}
 
 	// invalid command
-	stdoutShell := "invliad_command"
+	stdoutShell := "invalid_command"
 	sh := quartz.NewShellJob(stdoutShell)
 	sh.Execute(context.Background())
 	assertEqual(t, 127, sh.ExitCode)

--- a/quartz/job_test.go
+++ b/quartz/job_test.go
@@ -291,4 +291,5 @@ func TestShellJob_Execute(t *testing.T) {
 	sh := quartz.NewShellJob(stdoutShell)
 	sh.Execute(context.Background())
 	assertEqual(t, 127, sh.ExitCode)
+	// the return value is different under different platforms.
 }


### PR DESCRIPTION
### change

extend shell job

1. add stdout, stderr, result.
2. bash command is preferred，sh command is used only when bash command does not exist. because bash command is more complete than sh command.
3. add ut for shell execute.

