### PR TITLE
fix: data race for isStarted

### DIFF
--- a/quartz/scheduler.go
+++ b/quartz/scheduler.go
@@ -174,6 +174,9 @@ func (sched *StdScheduler) Wait(ctx context.Context) {
 
 // IsStarted determines whether the scheduler has been started.
 func (sched *StdScheduler) IsStarted() bool {
+	sched.mtx.Lock()
+	defer sched.mtx.Unlock()
+
 	return sched.started
 }
 


### PR DESCRIPTION
### change

if we run `go test -race ...` or `go run -race`,  raise data race in some case.