### PR TITLE
feat!: introduce JobDetail and JobKey for job scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,17 +26,17 @@ type Scheduler interface {
 	IsStarted() bool
 
 	// ScheduleJob schedules a job using a specified trigger.
-	ScheduleJob(ctx context.Context, job Job, trigger Trigger) error
+	ScheduleJob(ctx context.Context, jobDetail *JobDetail, trigger Trigger) error
 
 	// GetJobKeys returns the keys of all of the scheduled jobs.
-	GetJobKeys() []int
+	GetJobKeys() []*JobKey
 
 	// GetScheduledJob returns the scheduled job with the specified key.
-	GetScheduledJob(key int) (ScheduledJob, error)
+	GetScheduledJob(jobKey *JobKey) (ScheduledJob, error)
 
 	// DeleteJob removes the job with the specified key from the
 	// scheduler's execution queue.
-	DeleteJob(ctx context.Context, key int) error
+	DeleteJob(ctx context.Context, jobKey *JobKey) error
 
 	// Clear removes all of the scheduled jobs.
 	Clear() error
@@ -85,9 +85,6 @@ type Job interface {
 
 	// Description returns the description of the Job.
 	Description() string
-
-	// Key returns the unique key for the Job.
-	Key() int
 }
 ```
 
@@ -159,9 +156,12 @@ func main() {
 	functionJob := quartz.NewFunctionJob(func(_ context.Context) (int, error) { return 42, nil })
 
 	// register jobs to scheduler
-	sched.ScheduleJob(ctx, shellJob, cronTrigger)
-	sched.ScheduleJob(ctx, curlJob, quartz.NewSimpleTrigger(time.Second*7))
-	sched.ScheduleJob(ctx, functionJob, quartz.NewSimpleTrigger(time.Second*5))
+	sched.ScheduleJob(ctx, quartz.NewJobDetail(shellJob, quartz.NewJobKey("shellJob")),
+		cronTrigger)
+	sched.ScheduleJob(ctx, quartz.NewJobDetail(curlJob, quartz.NewJobKey("curlJob")),
+		quartz.NewSimpleTrigger(time.Second*7))
+	sched.ScheduleJob(ctx, quartz.NewJobDetail(functionJob, quartz.NewJobKey("functionJob")),
+		quartz.NewSimpleTrigger(time.Second*5))
 
 	// stop scheduler
 	sched.Stop()

--- a/examples/print_job.go
+++ b/examples/print_job.go
@@ -12,17 +12,15 @@ type PrintJob struct {
 	desc string
 }
 
+var _ quartz.Job = (*PrintJob)(nil)
+
 // Description returns the description of the PrintJob.
 func (pj *PrintJob) Description() string {
 	return pj.desc
 }
 
-// Key returns the unique PrintJob key.
-func (pj *PrintJob) Key() int {
-	return quartz.HashCode(pj.Description())
-}
-
 // Execute is called by a Scheduler when the Trigger associated with this job fires.
-func (pj *PrintJob) Execute(_ context.Context) {
+func (pj *PrintJob) Execute(_ context.Context) error {
 	fmt.Println("Executing " + pj.Description())
+	return nil
 }

--- a/examples/readme/main.go
+++ b/examples/readme/main.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/reugn/go-quartz/quartz"
+)
+
+func main() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// create scheduler
+	sched := quartz.NewStdScheduler()
+
+	// async start scheduler
+	sched.Start(ctx)
+
+	// create jobs
+	cronTrigger, _ := quartz.NewCronTrigger("1/5 * * * * *")
+	shellJob := quartz.NewShellJob("ls -la")
+
+	request, _ := http.NewRequest(http.MethodGet, "https://worldtimeapi.org/api/timezone/utc", nil)
+	curlJob := quartz.NewCurlJob(request)
+
+	functionJob := quartz.NewFunctionJob(func(_ context.Context) (int, error) { return 42, nil })
+
+	// register jobs to scheduler
+	sched.ScheduleJob(ctx, quartz.NewJobDetail(shellJob, quartz.NewJobKey("shellJob")),
+		cronTrigger)
+	sched.ScheduleJob(ctx, quartz.NewJobDetail(curlJob, quartz.NewJobKey("curlJob")),
+		quartz.NewSimpleTrigger(time.Second*7))
+	sched.ScheduleJob(ctx, quartz.NewJobDetail(functionJob, quartz.NewJobKey("functionJob")),
+		quartz.NewSimpleTrigger(time.Second*5))
+
+	// stop scheduler
+	sched.Stop()
+
+	// wait for all workers to exit
+	sched.Wait(ctx)
+}

--- a/quartz/function_job.go
+++ b/quartz/function_job.go
@@ -21,6 +21,8 @@ type FunctionJob[R any] struct {
 	jobStatus JobStatus
 }
 
+var _ Job = (*FunctionJob[any])(nil)
+
 // NewFunctionJob returns a new FunctionJob without an explicit description.
 func NewFunctionJob[R any](function Function[R]) *FunctionJob[R] {
 	return &FunctionJob[R]{
@@ -44,14 +46,9 @@ func (f *FunctionJob[R]) Description() string {
 	return f.desc
 }
 
-// Key returns the unique FunctionJob key.
-func (f *FunctionJob[R]) Key() int {
-	return HashCode(fmt.Sprintf("%s:%p", f.desc, f.function))
-}
-
 // Execute is called by a Scheduler when the Trigger associated with this job fires.
 // It invokes the held function, setting the results in Result and Error members.
-func (f *FunctionJob[R]) Execute(ctx context.Context) {
+func (f *FunctionJob[R]) Execute(ctx context.Context) error {
 	result, err := (*f.function)(ctx)
 	f.Lock()
 	if err != nil {
@@ -64,6 +61,7 @@ func (f *FunctionJob[R]) Execute(ctx context.Context) {
 		f.err = nil
 	}
 	f.Unlock()
+	return err
 }
 
 // Result returns the result of the FunctionJob.

--- a/quartz/function_job_test.go
+++ b/quartz/function_job_test.go
@@ -27,8 +27,10 @@ func TestFunctionJob(t *testing.T) {
 
 	sched := quartz.NewStdScheduler()
 	sched.Start(ctx)
-	sched.ScheduleJob(ctx, funcJob1, quartz.NewRunOnceTrigger(time.Millisecond*300))
-	sched.ScheduleJob(ctx, funcJob2, quartz.NewRunOnceTrigger(time.Millisecond*800))
+	sched.ScheduleJob(ctx, quartz.NewJobDetail(funcJob1, quartz.NewJobKey("funcJob1")),
+		quartz.NewRunOnceTrigger(time.Millisecond*300))
+	sched.ScheduleJob(ctx, quartz.NewJobDetail(funcJob2, quartz.NewJobKey("funcJob2")),
+		quartz.NewRunOnceTrigger(time.Millisecond*800))
 	time.Sleep(time.Second)
 	_ = sched.Clear()
 	sched.Stop()
@@ -44,7 +46,7 @@ func TestFunctionJob(t *testing.T) {
 	assertEqual(t, int(atomic.LoadInt32(&n)), 6)
 }
 
-func TestNewFunctionJobWithDescAndKey(t *testing.T) {
+func TestNewFunctionJobWithDesc(t *testing.T) {
 	jobDesc := "test job"
 
 	funcJob1 := quartz.NewFunctionJobWithDesc(jobDesc, func(_ context.Context) (string, error) {
@@ -56,8 +58,7 @@ func TestNewFunctionJobWithDescAndKey(t *testing.T) {
 	})
 
 	assertEqual(t, funcJob1.Description(), jobDesc)
-	assertEqual(t, funcJob1.Key(), funcJob1.Key())
-	assertNotEqual(t, funcJob1.Key(), funcJob2.Key())
+	assertEqual(t, funcJob2.Description(), jobDesc)
 }
 
 func TestFunctionJobRespectsContext(t *testing.T) {

--- a/quartz/job_detail.go
+++ b/quartz/job_detail.go
@@ -1,0 +1,66 @@
+package quartz
+
+import "time"
+
+// JobDetailOptions represents additional JobDetail properties.
+type JobDetailOptions struct {
+	// MaxRetries is the maximum number of retries before aborting the
+	// current job execution.
+	// Default: 0.
+	MaxRetries int
+
+	// RetryInterval is the fixed time interval between retry attempts.
+	// Default: 1 second.
+	RetryInterval time.Duration
+
+	// Replace specifies whether the job should replace an existing job
+	// with the same key.
+	// Default: false.
+	Replace bool
+}
+
+// NewDefaultJobDetailOptions returns a new instance of JobDetailOptions
+// with the default values.
+func NewDefaultJobDetailOptions() *JobDetailOptions {
+	return &JobDetailOptions{
+		MaxRetries:    0,
+		RetryInterval: time.Second,
+		Replace:       false,
+	}
+}
+
+// JobDetail conveys the detail properties of a given Job instance.
+type JobDetail struct {
+	job    Job
+	jobKey *JobKey
+	opts   *JobDetailOptions
+}
+
+// NewJobDetail creates and returns a new JobDetail.
+func NewJobDetail(job Job, jobKey *JobKey) *JobDetail {
+	return NewJobDetailWithOptions(job, jobKey, NewDefaultJobDetailOptions())
+}
+
+// NewJobDetailWithOptions creates and returns a new JobDetail configured as specified.
+func NewJobDetailWithOptions(job Job, jobKey *JobKey, opts *JobDetailOptions) *JobDetail {
+	return &JobDetail{
+		job:    job,
+		jobKey: jobKey,
+		opts:   opts,
+	}
+}
+
+// Job returns job.
+func (jd *JobDetail) Job() Job {
+	return jd.job
+}
+
+// JobKey returns jobKey.
+func (jd *JobDetail) JobKey() *JobKey {
+	return jd.jobKey
+}
+
+// Options returns opts.
+func (jd *JobDetail) Options() *JobDetailOptions {
+	return jd.opts
+}

--- a/quartz/job_key.go
+++ b/quartz/job_key.go
@@ -1,0 +1,46 @@
+package quartz
+
+import "fmt"
+
+const (
+	DefaultGroup = "default"
+)
+
+// JobKey represents the identifier of a scheduled job.
+// Keys are composed of both a name and group, and the name must be unique
+// within the group.
+// If only a name is specified then the default group name will be used.
+type JobKey struct {
+	name  string
+	group string
+}
+
+// NewJobKey returns a new NewJobKey using the given name.
+func NewJobKey(name string) *JobKey {
+	return &JobKey{
+		name:  name,
+		group: DefaultGroup,
+	}
+}
+
+// NewJobKeyWithGroup returns a new NewJobKey using the given name and group.
+func NewJobKeyWithGroup(name, group string) *JobKey {
+	if group == "" { // use default if empty
+		group = DefaultGroup
+	}
+	return &JobKey{
+		name:  name,
+		group: group,
+	}
+}
+
+// String returns string representation of the JobKey.
+func (jobKey *JobKey) String() string {
+	return fmt.Sprintf("%s::%s", jobKey.group, jobKey.name)
+}
+
+// Equals indicates whether some other JobKey is "equal to" this one.
+func (jobKey *JobKey) Equals(that *JobKey) bool {
+	return jobKey.name == that.name &&
+		jobKey.group == that.group
+}

--- a/quartz/job_test.go
+++ b/quartz/job_test.go
@@ -285,6 +285,5 @@ func TestCurlJob_WithCallback(t *testing.T) {
 	curlJob := quartz.NewCurlJobWithOptions(request, opts)
 	curlJob.Execute(context.Background())
 
-	assertEqual(t, 466866822, curlJob.Key())
 	assertEqual(t, quartz.OK, <-resultChan)
 }


### PR DESCRIPTION
* Introduce `JobDetail` and `JobKey` structures for job scheduling and identification.
* Allow a particular job to be scheduled multiple times with a distinct key and custom configuration.
* Change the `Execute` method in the `Job` interface to return an error.
* Remove the `Key` method from the `Job` interface and replace it with a `JobKey` identifier.
* Allow jobs to be scheduled when the Scheduler is not started.
* Allow scheduled jobs to be immediately retrieved.