### PR TITLE
fix!: reset scheduler after successfully clearing job queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ type Scheduler interface {
 	IsStarted() bool
 
 	// ScheduleJob schedules a job using a specified trigger.
-	ScheduleJob(ctx context.Context, jobDetail *JobDetail, trigger Trigger) error
+	ScheduleJob(jobDetail *JobDetail, trigger Trigger) error
 
 	// GetJobKeys returns the keys of all of the scheduled jobs.
 	GetJobKeys() []*JobKey
@@ -36,7 +36,7 @@ type Scheduler interface {
 
 	// DeleteJob removes the job with the specified key from the
 	// scheduler's execution queue.
-	DeleteJob(ctx context.Context, jobKey *JobKey) error
+	DeleteJob(jobKey *JobKey) error
 
 	// Clear removes all of the scheduled jobs.
 	Clear() error
@@ -156,11 +156,11 @@ func main() {
 	functionJob := quartz.NewFunctionJob(func(_ context.Context) (int, error) { return 42, nil })
 
 	// register jobs to scheduler
-	sched.ScheduleJob(ctx, quartz.NewJobDetail(shellJob, quartz.NewJobKey("shellJob")),
+	sched.ScheduleJob(quartz.NewJobDetail(shellJob, quartz.NewJobKey("shellJob")),
 		cronTrigger)
-	sched.ScheduleJob(ctx, quartz.NewJobDetail(curlJob, quartz.NewJobKey("curlJob")),
+	sched.ScheduleJob(quartz.NewJobDetail(curlJob, quartz.NewJobKey("curlJob")),
 		quartz.NewSimpleTrigger(time.Second*7))
-	sched.ScheduleJob(ctx, quartz.NewJobDetail(functionJob, quartz.NewJobKey("functionJob")),
+	sched.ScheduleJob(quartz.NewJobDetail(functionJob, quartz.NewJobKey("functionJob")),
 		quartz.NewSimpleTrigger(time.Second*5))
 
 	// stop scheduler

--- a/examples/main.go
+++ b/examples/main.go
@@ -49,11 +49,11 @@ func sampleScheduler(ctx context.Context, wg *sync.WaitGroup) {
 	jobDetail1 := quartz.NewJobDetail(&PrintJob{"First job"}, quartz.NewJobKey("job1"))
 	jobDetail2 := quartz.NewJobDetail(&PrintJob{"Second job"}, quartz.NewJobKey("job2"))
 	jobDetail3 := quartz.NewJobDetail(&PrintJob{"Third job"}, quartz.NewJobKey("job3"))
-	_ = sched.ScheduleJob(ctx, runOnceJobDetail, quartz.NewRunOnceTrigger(time.Second*5))
-	_ = sched.ScheduleJob(ctx, jobDetail1, quartz.NewSimpleTrigger(time.Second*12))
-	_ = sched.ScheduleJob(ctx, jobDetail2, quartz.NewSimpleTrigger(time.Second*6))
-	_ = sched.ScheduleJob(ctx, jobDetail3, quartz.NewSimpleTrigger(time.Second*3))
-	_ = sched.ScheduleJob(ctx, cronJob, cronTrigger)
+	_ = sched.ScheduleJob(runOnceJobDetail, quartz.NewRunOnceTrigger(time.Second*5))
+	_ = sched.ScheduleJob(jobDetail1, quartz.NewSimpleTrigger(time.Second*12))
+	_ = sched.ScheduleJob(jobDetail2, quartz.NewSimpleTrigger(time.Second*6))
+	_ = sched.ScheduleJob(jobDetail3, quartz.NewSimpleTrigger(time.Second*3))
+	_ = sched.ScheduleJob(cronJob, cronTrigger)
 
 	time.Sleep(time.Second * 10)
 
@@ -65,7 +65,7 @@ func sampleScheduler(ctx context.Context, wg *sync.WaitGroup) {
 
 	fmt.Println(scheduledJob.Trigger().Description())
 	fmt.Println("Before delete: ", sched.GetJobKeys())
-	_ = sched.DeleteJob(ctx, cronJob.JobKey())
+	_ = sched.DeleteJob(cronJob.JobKey())
 	fmt.Println("After delete: ", sched.GetJobKeys())
 
 	time.Sleep(time.Second * 2)
@@ -96,9 +96,9 @@ func sampleJobs(ctx context.Context, wg *sync.WaitGroup) {
 	shellJobDetail := quartz.NewJobDetail(shellJob, quartz.NewJobKey("shellJob"))
 	curlJobDetail := quartz.NewJobDetail(curlJob, quartz.NewJobKey("curlJob"))
 	functionJobDetail := quartz.NewJobDetail(functionJob, quartz.NewJobKey("functionJob"))
-	_ = sched.ScheduleJob(ctx, shellJobDetail, cronTrigger)
-	_ = sched.ScheduleJob(ctx, curlJobDetail, quartz.NewSimpleTrigger(time.Second*7))
-	_ = sched.ScheduleJob(ctx, functionJobDetail, quartz.NewSimpleTrigger(time.Second*3))
+	_ = sched.ScheduleJob(shellJobDetail, cronTrigger)
+	_ = sched.ScheduleJob(curlJobDetail, quartz.NewSimpleTrigger(time.Second*7))
+	_ = sched.ScheduleJob(functionJobDetail, quartz.NewSimpleTrigger(time.Second*3))
 
 	time.Sleep(time.Second * 10)
 

--- a/examples/readme/main.go
+++ b/examples/readme/main.go
@@ -28,11 +28,11 @@ func main() {
 	functionJob := quartz.NewFunctionJob(func(_ context.Context) (int, error) { return 42, nil })
 
 	// register jobs to scheduler
-	sched.ScheduleJob(ctx, quartz.NewJobDetail(shellJob, quartz.NewJobKey("shellJob")),
+	sched.ScheduleJob(quartz.NewJobDetail(shellJob, quartz.NewJobKey("shellJob")),
 		cronTrigger)
-	sched.ScheduleJob(ctx, quartz.NewJobDetail(curlJob, quartz.NewJobKey("curlJob")),
+	sched.ScheduleJob(quartz.NewJobDetail(curlJob, quartz.NewJobKey("curlJob")),
 		quartz.NewSimpleTrigger(time.Second*7))
-	sched.ScheduleJob(ctx, quartz.NewJobDetail(functionJob, quartz.NewJobKey("functionJob")),
+	sched.ScheduleJob(quartz.NewJobDetail(functionJob, quartz.NewJobKey("functionJob")),
 		quartz.NewSimpleTrigger(time.Second*5))
 
 	// stop scheduler

--- a/quartz/function_job_test.go
+++ b/quartz/function_job_test.go
@@ -27,9 +27,9 @@ func TestFunctionJob(t *testing.T) {
 
 	sched := quartz.NewStdScheduler()
 	sched.Start(ctx)
-	sched.ScheduleJob(ctx, quartz.NewJobDetail(funcJob1, quartz.NewJobKey("funcJob1")),
+	sched.ScheduleJob(quartz.NewJobDetail(funcJob1, quartz.NewJobKey("funcJob1")),
 		quartz.NewRunOnceTrigger(time.Millisecond*300))
-	sched.ScheduleJob(ctx, quartz.NewJobDetail(funcJob2, quartz.NewJobKey("funcJob2")),
+	sched.ScheduleJob(quartz.NewJobDetail(funcJob2, quartz.NewJobKey("funcJob2")),
 		quartz.NewRunOnceTrigger(time.Millisecond*800))
 	time.Sleep(time.Second)
 	_ = sched.Clear()

--- a/quartz/scheduler_test.go
+++ b/quartz/scheduler_test.go
@@ -48,16 +48,16 @@ func TestScheduler(t *testing.T) {
 	sched.Start(ctx)
 	assertEqual(t, sched.IsStarted(), true)
 
-	err = sched.ScheduleJob(ctx, quartz.NewJobDetail(shellJob, jobKeys[0]),
+	err = sched.ScheduleJob(quartz.NewJobDetail(shellJob, jobKeys[0]),
 		quartz.NewSimpleTrigger(time.Millisecond*700))
 	assertEqual(t, err, nil)
-	err = sched.ScheduleJob(ctx, quartz.NewJobDetail(curlJob, jobKeys[1]),
+	err = sched.ScheduleJob(quartz.NewJobDetail(curlJob, jobKeys[1]),
 		quartz.NewRunOnceTrigger(time.Millisecond))
 	assertEqual(t, err, nil)
-	err = sched.ScheduleJob(ctx, quartz.NewJobDetail(errShellJob, jobKeys[2]),
+	err = sched.ScheduleJob(quartz.NewJobDetail(errShellJob, jobKeys[2]),
 		quartz.NewRunOnceTrigger(time.Millisecond))
 	assertEqual(t, err, nil)
-	err = sched.ScheduleJob(ctx, quartz.NewJobDetail(errCurlJob, jobKeys[3]),
+	err = sched.ScheduleJob(quartz.NewJobDetail(errCurlJob, jobKeys[3]),
 		quartz.NewSimpleTrigger(time.Millisecond*800))
 	assertEqual(t, err, nil)
 
@@ -68,14 +68,14 @@ func TestScheduler(t *testing.T) {
 	_, err = sched.GetScheduledJob(jobKeys[0])
 	assertEqual(t, err, nil)
 
-	err = sched.DeleteJob(ctx, jobKeys[0]) // shellJob key
+	err = sched.DeleteJob(jobKeys[0]) // shellJob key
 	assertEqual(t, err, nil)
 
 	nonExistentJobKey := quartz.NewJobKey("NA")
 	_, err = sched.GetScheduledJob(nonExistentJobKey)
 	assertNotEqual(t, err, nil)
 
-	err = sched.DeleteJob(ctx, nonExistentJobKey)
+	err = sched.DeleteJob(nonExistentJobKey)
 	assertNotEqual(t, err, nil)
 
 	scheduledJobKeys = sched.GetJobKeys()
@@ -133,7 +133,6 @@ func TestSchedulerBlockingSemantics(t *testing.T) {
 				quartz.NewJobKey("timerJob"),
 			)
 			err := sched.ScheduleJob(
-				ctx,
 				timerJob,
 				quartz.NewSimpleTrigger(20*time.Millisecond),
 			)
@@ -240,7 +239,6 @@ func TestSchedulerCancel(t *testing.T) {
 				functionJob := quartz.NewJobDetail(quartz.NewFunctionJob(hourJob),
 					quartz.NewJobKey(fmt.Sprintf("functionJob_%d", i)))
 				if err := sched.ScheduleJob(
-					ctx,
 					functionJob,
 					quartz.NewSimpleTrigger(100*time.Millisecond),
 				); err != nil {


### PR DESCRIPTION
This PR undoes the breaking change introduced in (#83) by removing the ctx parameter from the `DeleteJob` method. Additionally, the context has been removed from the `ScheduleJob` method.