### PR TITLE
refactor(queue): remove unnecessary index field in scheduledJob

### DIFF
--- a/quartz/queue.go
+++ b/quartz/queue.go
@@ -12,7 +12,6 @@ type scheduledJob struct {
 	job      *JobDetail
 	trigger  Trigger
 	priority int64 // job priority, backed by its next run time.
-	index    int   // maintained by the heap.Interface methods.
 }
 
 var _ ScheduledJob = (*scheduledJob)(nil)
@@ -104,16 +103,12 @@ func (pq priorityQueue) Less(i, j int) bool {
 // Swap exchanges the indexes of the items.
 func (pq priorityQueue) Swap(i, j int) {
 	pq[i], pq[j] = pq[j], pq[i]
-	pq[i].index = i
-	pq[j].index = j
 }
 
 // Push implements the heap.Interface.Push.
 // Adds an element at index Len().
 func (pq *priorityQueue) Push(element interface{}) {
-	index := len(*pq)
 	item := element.(*scheduledJob)
-	item.index = index
 	*pq = append(*pq, item)
 }
 
@@ -123,7 +118,6 @@ func (pq *priorityQueue) Pop() interface{} {
 	old := *pq
 	n := len(old)
 	item := old[n-1]
-	item.index = -1 // for safety
 	*pq = old[0 : n-1]
 	return item
 }


### PR DESCRIPTION
Hi!

I found the job queue is implemented according to [example of container/heap - Go Packages](https://pkg.go.dev/container/heap#example-package-PriorityQueue). However, the index field is initialized in `Item` struct in the example (like the following code), while the `scheduleJob` struct doesn't do the same thing, so the index is always 0 in `scheduleJob` struct.
```go
	for value, priority := range items {
		pq[i] = &Item{
			value:    value,
			priority: priority,
			index:    i,        //  <----  this line
		}
		i++
	}

```
Actually, I don't think the index is needed in `scheduleJob`. The index hasn't been used before because it hasn't been set up properly. So I just removed it. 

Please let me know if there is anything I missed out.